### PR TITLE
Add new Martin Noergaard publication and fix author mapping

### DIFF
--- a/content/authors/Martin Noergaard/_index.md
+++ b/content/authors/Martin Noergaard/_index.md
@@ -1,10 +1,10 @@
 ---
 # Display name
-title: Martin Norgaard
+title: Martin Noergaard
 
 # Full Name (for SEO)
 first_name: Martin
-last_name: Norgaard
+last_name: Noergaard
 
 # Is this the primary user of the site?
 superuser: false
@@ -51,5 +51,3 @@ highlight_name: true
 user_groups:
   - Research Scientists
 ---
-### Website:
-- https://mnoergaard.github.io/

--- a/content/publication/eichhorn-2021-characterisation/index.md
+++ b/content/publication/eichhorn-2021-characterisation/index.md
@@ -4,7 +4,7 @@ title: Characterisation of children's head motion for Magnetic Resonance Imaging
 authors:
 - Hannah Eichhorn
 - Andreea-Veronica Vascan
-- Martin Nørgaard
+- Martin Noergaard
 - Andreas H Ellegaard
 - Jakob M Slipsager
 - Sune Høgild Keller

--- a/content/publication/greve-2020-estimating/index.md
+++ b/content/publication/greve-2020-estimating/index.md
@@ -2,9 +2,11 @@
 title: Estimating PET partial volume full-width-half-maximum directly from human data
 authors:
 - Douglas N Greve
-- Martinnd Ganz, Melanie Schain
-- Martinnd Svarer, Claus Nørgaard
-- Gitte Knudsen
+- Martin Schain
+- Melanie Ganz
+- Martin Noergaard
+- Claus Svarer
+- Gitte M Knudsen
 date: '2020-01-01'
 publishDate: '2025-03-21T10:46:43.026634Z'
 publication_types:

--- a/content/publication/hansen-2022-mapping/index.md
+++ b/content/publication/hansen-2022-mapping/index.md
@@ -7,7 +7,7 @@ authors:
 - Ross D Markello
 - Kelly Smart
 - Sylvia ML Cox
-- Martin Nørgaard
+- Martin Noergaard
 - Vincent Beliveau
 - Yanjun Wu
 - Jean-Dominique Gallezot

--- a/content/publication/koc-2024-associations/index.md
+++ b/content/publication/koc-2024-associations/index.md
@@ -3,7 +3,7 @@ title: 'Associations between behavioral and emotional problems and brain morphol
   in early adolescence: A neuroimaging study using the NRU Serotonin Atlas'
 authors:
 - Dogukan Koc
-- Martin Nørgaard
+- Martin Noergaard
 - Melanie Ganz
 - Ryan Muetzel
 - Hanan El Marroun

--- a/content/publication/norgaard-2015-estimation/index.md
+++ b/content/publication/norgaard-2015-estimation/index.md
@@ -2,7 +2,7 @@
 title: 'Estimation of Regional Seasonal Variations in SERT-levels using the FreeSurfer
   PET pipeline: a reproducibility study'
 authors:
-- Martin Nørgaard
+- Martin Noergaard
 - Melanie Ganz
 - Claus Svarer
 - Vincent Beliveau

--- a/content/publication/norgaard-2017-brain/index.md
+++ b/content/publication/norgaard-2017-brain/index.md
@@ -2,7 +2,7 @@
 title: 'Brain Networks Implicated in Seasonal Affective Disorder: A Neuroimaging PET
   Study of the Serotonin Transporter'
 authors:
-- M Nørgaard
+- Martin Noergaard
 - M Ganz
 - C Svarer
 - PM Fisher

--- a/content/publication/norgaard-2018-impact/index.md
+++ b/content/publication/norgaard-2018-impact/index.md
@@ -2,7 +2,7 @@
 title: The impact of preprocessing pipeline choice in univariate and multivariate
   analyses of pet data
 authors:
-- Martin Nørgaard
+- Martin Noergaard
 - Douglas N Greve
 - Claus Svarer
 - Stephen C Strother

--- a/content/publication/norgaard-2019-cerebral/index.md
+++ b/content/publication/norgaard-2019-cerebral/index.md
@@ -2,7 +2,7 @@
 title: 'Cerebral serotonin transporter measurements with [11C] DASB: a review on acquisition
   and preprocessing across 21 PET centres'
 authors:
-- Martin Nørgaard
+- Martin Noergaard
 - Melanie Ganz
 - Claus Svarer
 - Ling Feng

--- a/content/publication/norgaard-2019-optimization/index.md
+++ b/content/publication/norgaard-2019-optimization/index.md
@@ -2,7 +2,7 @@
 title: 'Optimization of preprocessing strategies in positron emission tomography (PET)
   neuroimaging: a [11C] DASB PET study'
 authors:
-- Martin Nørgaard
+- Martin Noergaard
 - Melanie Ganz
 - Claus Svarer
 - Vibe G Frokjaer

--- a/content/publication/norgaard-2019-p/index.md
+++ b/content/publication/norgaard-2019-p/index.md
@@ -2,7 +2,7 @@
 title: 'P. 263 The impact of different preprocessing strategies in positron emission
   tomography: a [11C] DASB Study'
 authors:
-- M Nørgaard
+- Martin Noergaard
 - M Ganz
 - C Svarer
 - VG Frokjaer

--- a/content/publication/norgaard-2019-preprocessing/index.md
+++ b/content/publication/norgaard-2019-preprocessing/index.md
@@ -2,7 +2,7 @@
 title: 'Preprocessing, prediction and significance: framework and application to brain
   imaging'
 authors:
-- Martin Nørgaard
+- Martin Noergaard
 - Brice Ozenne
 - Claus Svarer
 - Vibe G Frokjaer

--- a/content/publication/norgaard-2020-different/index.md
+++ b/content/publication/norgaard-2020-different/index.md
@@ -2,7 +2,7 @@
 title: 'Different preprocessing strategies lead to different conclusions: a [11C]
   DASB-PET reproducibility study'
 authors:
-- Martin Nørgaard
+- Martin Noergaard
 - Melanie Ganz
 - Claus Svarer
 - Vibe G Frokjaer

--- a/content/publication/norgaard-2021-high/index.md
+++ b/content/publication/norgaard-2021-high/index.md
@@ -2,7 +2,7 @@
 title: A high-resolution in vivo atlas of the human brain's benzodiazepine binding
   site of GABAA receptors
 authors:
-- Martin Nørgaard
+- Martin Noergaard
 - Vincent Beliveau
 - Melanie Ganz
 - Claus Svarer

--- a/content/publication/ozenne-2024-quantifying/index.md
+++ b/content/publication/ozenne-2024-quantifying/index.md
@@ -2,7 +2,7 @@
 title: Quantifying the impact of preprocessing strategies on statistical analyses
 authors:
 - Brice Ozenne
-- Martin Nørgaard
+- Martin Noergaard
 - Cyril Pernet
 - Melanie Ganz
 date: '2024-01-01'

--- a/content/publication/yan-2025-potential/cite.bib
+++ b/content/publication/yan-2025-potential/cite.bib
@@ -1,0 +1,9 @@
+@article{yan2025potential,
+  title = {A Potential Biomarker of Neuroinflammation},
+  author = {Yan, Xuefeng and Noergaard, Martin and Morse, Cheryl L and Liow, Jeih-san and Hong, Jinsoo and Greve, Douglas and Telu, Sanjay and Kim, Min-jeong and Santamaria, Jose A Montero and Galassi, Anthony and Feng, Ningping and Avram, Sarah K Williams and Usdin, Ted B and Wu, Shawn and Zhang, Andrea and Manly, Lester S and Jenkins, Madeline and Buskirk, Maia Van and Lee, Adrian and Zoghbi, Sami S and Pike, Victor W and Zanotti-Fregonara, Paolo and Innis, Robert B},
+  journal = {Journal of Nuclear Medicine},
+  pages = {1--7},
+  year = {2025},
+  doi = {10.2967/jnumed.124.268525},
+  keywords = {cox-2,human brain,neuroinflammation,PET}
+}

--- a/content/publication/yan-2025-potential/index.md
+++ b/content/publication/yan-2025-potential/index.md
@@ -1,0 +1,32 @@
+---
+title: 'A Potential Biomarker of Neuroinflammation'
+authors:
+- Xuefeng Yan
+- Martin Noergaard
+- Cheryl L Morse
+- Jeih-san Liow
+- Jinsoo Hong
+- Douglas Greve
+- Sanjay Telu
+- Min-jeong Kim
+- Jose A Montero Santamaria
+- Anthony Galassi
+- Ningping Feng
+- Sarah K Williams Avram
+- Ted B Usdin
+- Shawn Wu
+- Andrea Zhang
+- Lester S Manly
+- Madeline Jenkins
+- Maia Van Buskirk
+- Adrian Lee
+- Sami S Zoghbi
+- Victor W Pike
+- Paolo Zanotti-Fregonara
+- Robert B Innis
+date: '2025-01-01'
+publishDate: '2025-03-21T10:46:43Z'
+publication_types:
+- article-journal
+publication: '*Journal of Nuclear Medicine*'
+---

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,5 @@
+github.com/HugoBlox/hugo-blox-builder/modules/blox-bootstrap/v5 v5.9.7/go.mod h1:xZiTEEurbEwj/NhZohozvlyLCGVCT2wARHDAJeqKG/c=
+github.com/HugoBlox/hugo-blox-builder/modules/blox-core v0.3.1/go.mod h1:So8+V2U+TNxlXmcpZfdDX0muLh3PdJ7z92h30sv3bZg=
+github.com/HugoBlox/hugo-blox-builder/modules/blox-plugin-decap-cms v0.1.2-0.20231108143325-448ed0e3bd2b/go.mod h1:Njlsj3S1Z833TdX1nacJZzsiwGGhOq4Nilzo2BH/wQ8=
+github.com/HugoBlox/hugo-blox-builder/modules/blox-plugin-netlify v1.1.2-0.20231108143325-448ed0e3bd2b/go.mod h1:C7jfxMLv1bEUqbM9XDSmEpfOpS8w06OgqNDEcbuRgL4=
+github.com/HugoBlox/hugo-blox-builder/modules/blox-seo v0.2.2/go.mod h1:NsESu6cEms1DgH84icCyylElg2Zu8A0f7Fma5JR0LZE=

--- a/publications.bib
+++ b/publications.bib
@@ -1124,3 +1124,12 @@ year = {2023}
   url = {https://archive.ismrm.org/2024/2670.html}
 }
 
+@article{yan2025potential,
+  title = {A Potential Biomarker of Neuroinflammation},
+  author = {Yan, Xuefeng and Noergaard, Martin and Morse, Cheryl L and Liow, Jeih-san and Hong, Jinsoo and Greve, Douglas and Telu, Sanjay and Kim, Min-jeong and Santamaria, Jose A Montero and Galassi, Anthony and Feng, Ningping and Avram, Sarah K Williams and Usdin, Ted B and Wu, Shawn and Zhang, Andrea and Manly, Lester S and Jenkins, Madeline and Buskirk, Maia Van and Lee, Adrian and Zoghbi, Sami S and Pike, Victor W and Zanotti-Fregonara, Paolo and Innis, Robert B},
+  journal = {Journal of Nuclear Medicine},
+  pages = {1--7},
+  year = {2025},
+  doi = {10.2967/jnumed.124.268525},
+  keywords = {cox-2,human brain,neuroinflammation,PET}
+}


### PR DESCRIPTION
## Summary
- add the 2025 Journal of Nuclear Medicine publication co-authored by Martin Noergaard to the shared `publications.bib` file and create the corresponding publication entry
- standardize all publication front matter to reference Martin Noergaard consistently and update his author profile so the publications widget can link to him
- record the Go module checksums required by Hugo in `go.sum`

## Testing
- not run (Hugo is not available in the execution environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915d6dea074833081d3a969f8bae871)