### PR TITLE
Fix homepage logo path resolution

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -12,7 +12,7 @@ sections:
         filename: lab_pic.jpg
       text: |
         <p>
-          <img src="/assets/media/lnn-logo.png" alt="LNN logo" style="max-width: 120px; height: auto; margin-right: 1rem; vertical-align: middle;" />
+          <img src="assets/media/lnn-logo.png" alt="LNN logo" style="max-width: 120px; height: auto; margin-right: 1rem; vertical-align: middle;" />
           The Lab for Neuroimaging and Neuroinformatics (LNN) @ UCPH focuses on leveraging advanced imaging technologies and computational methods to study the human brain. We integrate neuroimaging data with neuroinformatics approaches to understand brain structure, function, and connectivity. Our research areas typically include the development and application of machine learning algorithms, image analysis techniques, and data integration methods to advance the field of neuroscience and improve clinical outcomes in neurology and psychiatry. Our work often involves interdisciplinary collaboration, bridging gaps between computational sciences and neuroscience.
         </p>
 


### PR DESCRIPTION
### Motivation
- The homepage logo used an absolute `/assets/...` `img` `src` which prevented Hugo's page rendering from resolving the asset correctly, so the path was changed to a project-relative reference.

### Description
- Update `content/_index.md` to change the logo `img` `src` from `/assets/media/lnn-logo.png` to `assets/media/lnn-logo.png` so the asset resolves during site rendering.

### Testing
- Ran `rg` to locate the image reference and confirmed the asset exists at `assets/media/lnn-logo.png`, but `hugo version` failed because `hugo` is not installed and a Playwright visit to `http://127.0.0.1:1313` failed due to no local server, so a full render/preview could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7d477e6348330ad42bf584a6d46be)